### PR TITLE
Feature: shift select

### DIFF
--- a/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.html
@@ -3,7 +3,7 @@
     <div class="check-box" *ngFor="let num of questionDetails.msqChoices; let i = index;">
       <label class="margin-right-15px">
         <input type="checkbox" class="margin-right-15px" [checked]="isMsqOptionSelected[i]"
-               (click)="updateSelectedAnswers(i)" [disabled]="isDisabled">
+               (click)="updateSelectedAnswers(i, $event)" [disabled]="isDisabled">
         <strong>{{ questionDetails.msqChoices[i] }}</strong>
       </label>
     </div>

--- a/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
@@ -50,7 +50,7 @@ export class MsqQuestionEditAnswerFormComponent
   /**
    * Updates the answers to include/exclude the Msq option specified by the index.
    */
-  updateSelectedAnswers(index: number, $event : string): void {
+  updateSelectedAnswers(index: number, $event: Event): void {
     let newAnswers: string[] = [];
 
     if (!this.isNoneOfTheAboveEnabled) {

--- a/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
@@ -123,7 +123,7 @@ export class MsqQuestionEditAnswerFormComponent
       }, 0);
     } else {
       // remove other answer (last element) from the answer list
-      fieldsToUpdate.answers.splice(-1, 1); // what's happening here? does the answer list have a restricted number of elements
+      fieldsToUpdate.answers.splice(-1, 1); // what is happening here? does the answer list have a restricted number of elements
       fieldsToUpdate.otherFieldContent = '';
     }
     this.lastSelectedOptionIdx = -1;

--- a/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
@@ -50,7 +50,7 @@ export class MsqQuestionEditAnswerFormComponent
   /**
    * Updates the answers to include/exclude the Msq option specified by the index.
    */
-  updateSelectedAnswers(index: number, $event: Event): void {
+  updateSelectedAnswers(index: number, $event: KeyboardEvent): void {
     let newAnswers: string[] = [];
 
     if (!this.isNoneOfTheAboveEnabled) {

--- a/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
@@ -62,9 +62,9 @@ export class MsqQuestionEditAnswerFormComponent
     const isCurrActionSelect = (selectedIndexInResponseArray === -1);
 
     // src: https://stackoverflow.com/questions/37078709/angular-2-check-if-shift-key-is-down-when-an-element-is-clicked?rq=1
-    console.log("shiftKey", $event.shiftKey, "isLastAction", this.isLastActionSelect, "curr", isCurrActionSelect)
-    console.log("previous deets", this.responseDetails.answers);
 
+    /* to keep things simple, we enable shift select functionality only when
+    previous action and curr action are both select or are both deselect */
     if ($event.shiftKey && (this.isLastActionSelect === isCurrActionSelect)) {
         let i = Math.min(index, this.lastSelectedOptionIdx),
             l = Math.max(index, this.lastSelectedOptionIdx);
@@ -75,7 +75,6 @@ export class MsqQuestionEditAnswerFormComponent
 
                 if (this.responseDetails.answers.indexOf(this.questionDetails.msqChoices[i]) !== -1) continue; // without this you will be double selecting an item
 
-                console.log("unshift", this.questionDetails.msqChoices[i])
                 newAnswers.unshift(this.questionDetails.msqChoices[i]);
             }
             this.isLastActionSelect = true;
@@ -87,22 +86,10 @@ export class MsqQuestionEditAnswerFormComponent
                 if (j === -1) continue; // an option in the middle of this loop might already have been deselected. without this if, you'll be deselecting a random item at the end of the array.
 
                 newAnswers.splice(j, 1);
-                console.log("splice", j, this.responseDetails);
             }
             this.isLastActionSelect = false;
         }
-
-        // gmail supports one more thing
-        /*
-            if
-            [][][][] click 1st
-            [!][][][] shift click 4th
-            [!][!][!][!] shift click 2nd
-            [!][][][] google does this
-        */
-
-
-    } else {
+    } else { // no shift key functionality. i.e. perform the operations for one individual msqChoice
         if (isCurrActionSelect) {
             newAnswers.unshift(this.questionDetails.msqChoices[index]);
             this.isLastActionSelect = true;
@@ -113,25 +100,9 @@ export class MsqQuestionEditAnswerFormComponent
         }
     }
 
-    console.log("now", newAnswers);
-
     this.lastSelectedOptionIdx = index;
 
     this.triggerResponseDetailsChange('answers', newAnswers);
-
-    /*
-    if shiftkey then
-        curr = deselect &&
-        prev = deselect
-            then loop through indexes of and splice away
-            return
-        curr !== prev
-            then ignore, behave as if no shiftkey (go to next)
-        curr == prev == select action
-            then loop through indexes
-            unshift
-
-    */
   }
 
   /**


### PR DESCRIPTION
Allow the front-end to recognize when shift key is pressed during selection of MSQ choices. This allows users to select many choices faster.

https://user-images.githubusercontent.com/49683462/122638264-c9871380-d125-11eb-9bfa-5c30206a8675.mp4

This change also applies to mass deselecting options, which is not captured in video (file size constraint).

This feature is implemented in the function `updateSelectedAnswers` by keeping track of the last index selected, what the last action is (select or deselect), and whether the shift key is being pressed.